### PR TITLE
Temp fix setting default protocol version

### DIFF
--- a/integration-impl/pom.xml
+++ b/integration-impl/pom.xml
@@ -3,7 +3,8 @@
 
   <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>signservice-integration-impl</artifactId>  
+  <artifactId>signservice-integration-impl</artifactId>
+  <version>1.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <parent>
@@ -155,6 +156,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
+      <version>1.18.22</version>
     </dependency>
     
     <dependency>

--- a/integration-impl/src/main/java/se/idsec/signservice/integration/process/impl/DefaultSignRequestProcessor.java
+++ b/integration-impl/src/main/java/se/idsec/signservice/integration/process/impl/DefaultSignRequestProcessor.java
@@ -290,6 +290,17 @@ public class DefaultSignRequestProcessor implements SignRequestProcessor {
 
     SignRequestExtension signRequestExtension = dssExtObjectFactory.createSignRequestExtension();
 
+    // Set default version
+    // TODO Make configurable per policy/profile
+    /*
+     * IMPORTANT NOTE: The current fix is temporary, allowing default version to be set by env variable
+     * This shall be replaced by a permanent fix that allows default version to be set by configuration variable
+     */
+    String defaultVersion = System.getenv("DEFAULT_SIGREQEXT_VERSION");
+    if (StringUtils.isNotBlank(defaultVersion)){
+      signRequestExtension.setVersion(defaultVersion);
+    }
+
     // RequestTime
     //
     signRequestExtension.setRequestTime(getNow());
@@ -549,8 +560,8 @@ public class DefaultSignRequestProcessor implements SignRequestProcessor {
     /**
      * Copy constructor.
      * 
-     * @param m
-     *          the map to initialize the object with
+     * @param extension
+     *          the extension to initialize the object with
      */
     public DocumentExtension(final Extension extension) {
       super(extension);


### PR DESCRIPTION
This pull request illustrates the temporary changes that has been applied to provide the capability to configure the selected protocol version for sign requests.

This pull request is not intended to be merged, but simply to highlight the temporary changes.

Changes should be done in accordance with Issue #40