### PR TITLE
Replace spring stringutil with commons stringutil

### DIFF
--- a/integration-impl/src/main/java/se/idsec/signservice/integration/document/impl/VisiblePdfSignatureRequirementValidator.java
+++ b/integration-impl/src/main/java/se/idsec/signservice/integration/document/impl/VisiblePdfSignatureRequirementValidator.java
@@ -17,7 +17,7 @@ package se.idsec.signservice.integration.document.impl;
 
 import java.util.List;
 
-import org.springframework.util.StringUtils;
+import org.apache.commons.lang.StringUtils;
 
 import se.idsec.signservice.integration.config.IntegrationServiceConfiguration;
 import se.idsec.signservice.integration.core.validation.AbstractInputValidator;
@@ -58,7 +58,7 @@ public class VisiblePdfSignatureRequirementValidator extends
             : null
         : null;
 
-    if (!StringUtils.hasText(object.getTemplateImageRef())) {
+    if (StringUtils.isEmpty(object.getTemplateImageRef())) {
       result.rejectValue("templateImageRef", "PDF template reference is required");
     }
     else if (template == null) {

--- a/integration-impl/src/main/java/se/idsec/signservice/integration/document/impl/VisiblePdfSignatureRequirementValidator.java
+++ b/integration-impl/src/main/java/se/idsec/signservice/integration/document/impl/VisiblePdfSignatureRequirementValidator.java
@@ -58,7 +58,7 @@ public class VisiblePdfSignatureRequirementValidator extends
             : null
         : null;
 
-    if (StringUtils.isEmpty(object.getTemplateImageRef())) {
+    if (StringUtils.isBlank(object.getTemplateImageRef())) {
       result.rejectValue("templateImageRef", "PDF template reference is required");
     }
     else if (template == null) {


### PR DESCRIPTION
This PR removes a small dependency to Spring by replacing Spring StringUtil with Apache Commons Stringutil,
for the class VisiblePdfSignatureRequirementValidator. The usage of Commons StringUtil is used in most
other classes in the project, so (hopefully) this PR is line with that practice.

Signed-off-by: Josef Andersson <josef.andersson@gmail.com>