### PR TITLE
Add JsonDeserialize annotation to DefaultSignatureState

### DIFF
--- a/integration-impl/pom.xml
+++ b/integration-impl/pom.xml
@@ -4,6 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>signservice-integration-impl</artifactId>  
+  <version>1.3.5-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <parent>

--- a/integration-impl/src/main/java/se/idsec/signservice/integration/state/impl/DefaultSignatureState.java
+++ b/integration-impl/src/main/java/se/idsec/signservice/integration/state/impl/DefaultSignatureState.java
@@ -20,6 +20,7 @@ import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -40,6 +41,7 @@ import se.idsec.signservice.integration.state.SignatureSessionState;
  * @author Martin Lindström (martin@idsec.se)
  * @author Stefan Santesson (stefan@idsec.se)
  */
+@JsonDeserialize(as = DefaultSignatureState.class)
 @JsonInclude(Include.NON_NULL)
 @Builder
 @ToString

--- a/integration-impl/src/test/java/se/idsec/signservice/state/impl/DefaultSignatureStateTest.java
+++ b/integration-impl/src/test/java/se/idsec/signservice/state/impl/DefaultSignatureStateTest.java
@@ -1,0 +1,114 @@
+package se.idsec.signservice.state.impl;
+
+import static org.junit.Assert.assertEquals;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import se.idsec.signservice.integration.SignRequestInput;
+import se.idsec.signservice.integration.SignServiceIntegrationService;
+import se.idsec.signservice.integration.authentication.AuthnRequirements;
+import se.idsec.signservice.integration.certificate.SigningCertificateRequirements;
+import se.idsec.signservice.integration.core.Extension;
+import se.idsec.signservice.integration.signmessage.SignMessageParameters;
+import se.idsec.signservice.integration.state.SignatureSessionState;
+import se.idsec.signservice.integration.state.impl.DefaultSignatureState;
+
+public class DefaultSignatureStateTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    public void testJsonSerializesAndDeserializes() throws Exception {
+
+        DefaultSignatureState signatureState = defaultSignatureState();
+        String jsonString = objectMapper.writeValueAsString(signatureState);
+
+        DefaultSignatureState deserializedSignatureState = objectMapper.readValue(jsonString,
+                DefaultSignatureState.class);
+        assertEquals(signatureState.getId(), deserializedSignatureState.getId());
+        assertEquals(signatureState.getOwnerId(), deserializedSignatureState.getOwnerId());
+
+        //Why no an simple assertEquals - all objects in the SignatureSessionState graph
+        // would then have to implement equals, hashcode, and currently, they don't
+        //so, we just use reflection to pick most of them.
+        // If improving further in the future, that would be that would be the way to go imho,
+        // (not expanding on this reflection test, but aim to remove any such need)
+        Field[] allFields = FieldUtils.getAllFields(SignatureSessionState.class);
+        Arrays.stream(allFields).forEach(field -> {
+            System.out.println(field.getName());
+            field.setAccessible(true);
+            switch (field.getName()) {
+                case "correlationId":
+                    break;
+                case "policy":
+                    assertField(field, deserializedSignatureState, signatureState);
+                    break;
+                case "expectedReturnUrl":
+                    assertField(field, deserializedSignatureState, signatureState);
+                    break;
+                case "tbsDocuments":
+                    assertField(field, deserializedSignatureState, signatureState);
+                    break;
+                case "signRequest":
+                    assertField(field, deserializedSignatureState, signatureState);
+                    break;
+                case "encodedSignRequest":
+                    assertField(field, deserializedSignatureState, signatureState);
+                    break;
+                default:
+                    System.out.println("unknown");
+
+            }
+        }
+
+        );
+    }
+
+    private void assertField(Field field, DefaultSignatureState deserializedSignatureState,
+            DefaultSignatureState signatureState) {
+        try {
+            assertEquals(field.get(deserializedSignatureState.getState()), field.get(signatureState.getState()));
+        } catch (IllegalArgumentException | IllegalAccessException e) {
+            e.printStackTrace();
+        }
+    }
+
+    // TODO: this test object setup could certainly improve with a better object setup
+    // Currently we are only testing the general serialize/deseralize mechanism,
+    // and are not putting much effort into the field values themselves.
+    // So good enough for that.
+    private DefaultSignatureState defaultSignatureState() {
+
+        final SignRequestInput requestInput = SignRequestInput.builder().build();
+        requestInput.setCorrelationId("correlationId");
+        requestInput.setAuthnRequirements(AuthnRequirements.builder().build());
+        requestInput.setCertificateRequirements(SigningCertificateRequirements.builder().build());
+        requestInput.setDestinationUrl("http://desturl.test");
+        requestInput.setExtension(Extension.builder().build());
+        requestInput.setPolicy("policy");
+        requestInput.setReturnUrl("http://returnurl.test");
+        requestInput.setSignMessageParameters(SignMessageParameters.builder().signMessage("signMessage").build());
+        requestInput.setSignRequesterID("signRequesterId");
+        requestInput.setSignatureAlgorithm("signatureAlg");
+        requestInput.setTbsDocuments(List.of());
+
+        final SignatureSessionState sessionState = SignatureSessionState.builder()
+                .ownerId(requestInput.getExtensionValue(SignServiceIntegrationService.OWNER_ID_EXTENSION_KEY))
+                .correlationId(requestInput.getCorrelationId())
+                .policy(requestInput.getPolicy())
+                .expectedReturnUrl(requestInput.getReturnUrl())
+                .tbsDocuments(requestInput.getTbsDocuments())
+                .signMessage(requestInput.getSignMessageParameters())
+                .encodedSignRequest("encodedSignRequest")
+                .build();
+
+        return DefaultSignatureState.builder().id("id").state(sessionState).build();
+    }
+}


### PR DESCRIPTION
**What**:
This PR adds a JsonDeserialize Annotation to the DefaultSignatureState.

**Why**

A Quarkus integration, using the 
DefaultSignatureStateProcessor -> method setStateCache(.. 

Methos setStateCache takes interface IntegrationServiceStateCache ->
with signature ->public interface IntegrationServiceStateCache extends IntegrationServiceCache<CacheableSignatureState> {…

Works fine for overriding and (in our specific case) do an Redis put get based cache.

But...
Quarkus Redis implementation uses json/jackson to serialize/deserialize:
https://quarkus.io/guides/redis-reference#serialization-and-deserialization

While we would gladly use the given implementation of CachableSignatureState -> DefaultSignatureState.
It does not work in this use case, as jackson will interpret is as a RestClientSignatureState due to the annotation on interface SignatureSite.
Fine, use a RestClientSignatureState then one might think - but that object is not an implementation of CacheableSignatureState, so that would not work.

The proposed solution is simple, and I can't see the we are complicating things.

- Add a JsonDeserialize(as = DefaultSignatureState.class) to DefaultSignatureState object.

That way it will always get the right deserialization, without the enduser (us) having to either add an extra deserializer, or as we do currently - Implement a simple CachbleSignatureStateImpl-object that basically just adds that annotation and is a clone of DefaultSignatureState. That works, but, always nicer to have the direct support from the library it self, (and it would spare us an object-impl in the integration:).

(There is a very basic test written for this, which just tests the serialization/deserialization mechanism  )



