### PR TITLE
Update PdfSignaturePagePreparator

### DIFF
--- a/integration-impl/src/main/java/se/idsec/signservice/integration/impl/PdfSignaturePagePreparator.java
+++ b/integration-impl/src/main/java/se/idsec/signservice/integration/impl/PdfSignaturePagePreparator.java
@@ -19,6 +19,7 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import se.idsec.signservice.integration.ExtendedSignServiceIntegrationService;
 import se.idsec.signservice.integration.config.IntegrationServiceConfiguration;
+import se.idsec.signservice.integration.config.IntegrationServiceDefaultConfiguration;
 import se.idsec.signservice.integration.core.error.InputValidationException;
 import se.idsec.signservice.integration.core.error.SignServiceIntegrationException;
 import se.idsec.signservice.integration.document.pdf.PdfAConsistencyCheckException;
@@ -63,7 +64,7 @@ public interface PdfSignaturePagePreparator {
    */
   PreparedPdfDocument preparePdfDocument(@Nonnull final byte[] pdfDocument,
       @Nullable final PdfSignaturePagePreferences signaturePagePreferences,
-      @Nonnull final IntegrationServiceConfiguration policyConfiguration,
+      @Nonnull final IntegrationServiceDefaultConfiguration policyConfiguration,
       @Nullable final Boolean returnDocumentReference, @Nullable final String callerId)
       throws InputValidationException, PdfSignaturePageFullException, PdfAConsistencyCheckException,
       PdfContainsAcroformException, PdfContainsEncryptionDictionaryException, SignServiceIntegrationException;

--- a/pdf/pom.xml
+++ b/pdf/pom.xml
@@ -4,6 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>signservice-integration-pdf</artifactId>
+  <version>2.3.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <parent>
@@ -64,7 +65,8 @@
     <dependency>
       <groupId>se.idsec.signservice.integration</groupId>
       <artifactId>signservice-integration-impl</artifactId>
-      <version>${project.version}</version>
+      <version>2.3.1</version>
+<!--      <version>${project.version}</version>-->
     </dependency>
 
     <dependency>

--- a/pdf/src/main/java/se/idsec/signservice/integration/document/pdf/DefaultPdfSignaturePagePreparator.java
+++ b/pdf/src/main/java/se/idsec/signservice/integration/document/pdf/DefaultPdfSignaturePagePreparator.java
@@ -22,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import se.idsec.signservice.integration.ExtendedSignServiceIntegrationService;
 import se.idsec.signservice.integration.config.IntegrationServiceConfiguration;
+import se.idsec.signservice.integration.config.IntegrationServiceDefaultConfiguration;
 import se.idsec.signservice.integration.core.DocumentCache;
 import se.idsec.signservice.integration.core.error.ErrorCode;
 import se.idsec.signservice.integration.core.error.InputValidationException;
@@ -71,7 +72,7 @@ public class DefaultPdfSignaturePagePreparator implements PdfSignaturePagePrepar
   @Nonnull
   public PreparedPdfDocument preparePdfDocument(@Nonnull final byte[] pdfDocument,
       @Nullable final PdfSignaturePagePreferences signaturePagePreferences,
-      @Nonnull final IntegrationServiceConfiguration policyConfiguration,
+      @Nonnull final IntegrationServiceDefaultConfiguration policyConfiguration,
       @Nullable final Boolean returnDocumentReference, @Nullable final String callerId)
       throws SignServiceIntegrationException {
 
@@ -191,7 +192,7 @@ public class DefaultPdfSignaturePagePreparator implements PdfSignaturePagePrepar
    *     encryption dictionary is detected
    */
   private boolean checkAndUpdateDocument(@Nonnull final PDDocument document,
-      @Nonnull final IntegrationServiceConfiguration policyConfiguration, @Nonnull final PreparedPdfDocument result)
+      @Nonnull final IntegrationServiceDefaultConfiguration policyConfiguration, @Nonnull final PreparedPdfDocument result)
       throws DocumentProcessingException, PdfContainsAcroformException, PdfContainsEncryptionDictionaryException {
 
     final List<PdfPrepareReport.PrepareActions> prepareActions = this.issueHandler.fixIssues(document,
@@ -220,7 +221,7 @@ public class DefaultPdfSignaturePagePreparator implements PdfSignaturePagePrepar
    */
   private PDDocument processSignPageAndVisibleSignature(@Nonnull final PDDocument document,
       @Nonnull final PdfSignaturePagePreferences signPagePreferences,
-      @Nonnull final IntegrationServiceConfiguration configuration,
+      @Nonnull final IntegrationServiceDefaultConfiguration configuration,
       @Nonnull final PreparedPdfDocument result) throws SignServiceIntegrationException {
 
     // Check if the document already has signatures (we assume that there is a PDF signature page and that each
@@ -303,7 +304,7 @@ public class DefaultPdfSignaturePagePreparator implements PdfSignaturePagePrepar
 
   /**
    * Validates the input supplied to
-   * {@link #preparePdfDocument(byte[], PdfSignaturePagePreferences, IntegrationServiceConfiguration, Boolean, String)}
+   * {@link #preparePdfDocument(byte[], PdfSignaturePagePreferences, IntegrationServiceDefaultConfiguration, Boolean, String)}
    *
    * @param pdfDocument the PDF document
    * @param signaturePagePreferences the signature page preferences
@@ -312,7 +313,7 @@ public class DefaultPdfSignaturePagePreparator implements PdfSignaturePagePrepar
    */
   private void validateInput(final byte[] pdfDocument,
       final PdfSignaturePagePreferences signaturePagePreferences,
-      final IntegrationServiceConfiguration policyConfiguration)
+      final IntegrationServiceDefaultConfiguration policyConfiguration)
       throws InputValidationException {
 
     if (pdfDocument == null) {

--- a/pdf/src/main/java/se/idsec/signservice/integration/document/pdf/signpage/impl/PdfSignaturePagePreferencesValidator.java
+++ b/pdf/src/main/java/se/idsec/signservice/integration/document/pdf/signpage/impl/PdfSignaturePagePreferencesValidator.java
@@ -17,6 +17,7 @@ package se.idsec.signservice.integration.document.pdf.signpage.impl;
 
 import jakarta.annotation.Nullable;
 import se.idsec.signservice.integration.config.IntegrationServiceConfiguration;
+import se.idsec.signservice.integration.config.IntegrationServiceDefaultConfiguration;
 import se.idsec.signservice.integration.core.validation.AbstractInputValidator;
 import se.idsec.signservice.integration.core.validation.ValidationResult;
 import se.idsec.signservice.integration.document.impl.PdfSignaturePageValidator;
@@ -32,7 +33,7 @@ import se.idsec.signservice.integration.document.pdf.PdfSignaturePagePreferences
  * @author Stefan Santesson (stefan@idsec.se)
  */
 public class PdfSignaturePagePreferencesValidator
-    extends AbstractInputValidator<PdfSignaturePagePreferences, IntegrationServiceConfiguration> {
+    extends AbstractInputValidator<PdfSignaturePagePreferences, IntegrationServiceDefaultConfiguration> {
 
   /** Validator for sign pages. */
   private final PdfSignaturePageValidator pdfSignaturePageValidator = new ExtendedPdfSignaturePageValidator();
@@ -45,7 +46,7 @@ public class PdfSignaturePagePreferencesValidator
   @Override
   public ValidationResult validate(
       final PdfSignaturePagePreferences object, @Nullable final String objectName,
-      final IntegrationServiceConfiguration hint) {
+      final IntegrationServiceDefaultConfiguration hint) {
 
     final ValidationResult result = new ValidationResult(objectName);
     if (object == null) {


### PR DESCRIPTION
This proposes an update to PdfSignaturePagePreparator where policy configuration only requires the base class IntegrationServiceDefaultConfiguration holding all necessary configuration properties,
instead of the extension class IntegrationServiceConfiguration requiring many additional parameters
not needed for the preparePdfDocument function.

The rationale for this change request is to make the preparePdfDocument() more available in a natural manner to Java API based integration use where the extra parameters required by the extension class IntegrationServiceConfiguration are not naturally available. 