### PR TITLE
Fix compile errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,13 @@
           <version>3.14.0</version>
           <configuration>
             <release>${java.version}</release>
+            <annotationProcessorPaths>
+              <path>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>1.18.38</version>
+              </path>
+            </annotationProcessorPaths>
           </configuration>
         </plugin>
 


### PR DESCRIPTION
I got a lot of compilation errors, for example

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.14.0:compile (default-compile) on project signservice-integration-impl: Compilation failure: Compilation failure: 
[ERROR] /Volumes/t1/ss/ss3/signservice-integration/integration-impl/src/main/java/se/idsec/signservice/integration/SignServiceIntegrationServiceInitializer.java:[83,7] cannot find symbol
[ERROR]   symbol:   variable log
[ERROR]   location: class se.idsec.signservice.integration.SignServiceIntegrationServiceInitializer
[ERROR] /Volumes/t1/ss/ss3/signservice-integration/integration-impl/src/main/java/se/idsec/signservice/integration/SignServiceIntegrationServiceInitializer.java:[91,5] cannot find symbol
[ERROR]   symbol:   variable log
[ERROR]   location: class se.idsec.signservice.integration.SignServiceIntegrationServiceInitializer
[ERROR] /Volumes/t1/ss/ss3/signservice-integration/integration-impl/src/main/java/se/idsec/signservice/integration/SignServiceIntegrationServiceInitializer.java:[98,5] cannot find symbol
[ERROR]   symbol:   variable log
[ERROR]   location: class se.idsec.signservice.integration.SignServiceIntegrationServiceInitializer
[ERROR] /Volumes/t1/ss/ss3/signservice-integration/integration-impl/src/main/java/se/idsec/signservice/integration/SignServiceIntegrationServiceInitializer.java:[105,5] cannot find symbol
```

AI tools proposed the patch to specify lombok version which solves the compilation errors.