### PR TITLE
Force XRef renumbering

### DIFF
--- a/pdf/src/main/java/se/idsec/signservice/integration/document/pdf/utils/PDDocumentUtils.java
+++ b/pdf/src/main/java/se/idsec/signservice/integration/document/pdf/utils/PDDocumentUtils.java
@@ -89,6 +89,7 @@ public class PDDocumentUtils {
   public static byte[] toBytes(final PDDocument document) throws DocumentProcessingException {
     try (final ByteArrayOutputStream bos = new ByteArrayOutputStream();
         final BufferedOutputStream os = new BufferedOutputStream(bos)) {
+      document.getDocument().setHighestXRefObjectNumber(0);
       document.save(os, CompressParameters.NO_COMPRESSION);
       os.flush();
       return bos.toByteArray();


### PR DESCRIPTION
When a signature page is added to the document and the signature page has high XRef numbering, the document size increases by about 1 Mbyte because of the sparseness for older PDF versions (1.3 for example). This occurs in the current version eduSign, where 150 kB files turn into 1.4 Mbyte files when signed.

Setting setHighestXRefObjectNumber(0); should cause the following document.save() to renumber all XRefs from 1, thereby compacting the XRef table and saving a lot of space in the resulting file.

However I haven't been able to test the patch due to lack of testing infrastructure. So please do a code review, integration testing, etc if you think this could be a solution to the XRef inflation when extra pages are added.