### PR TITLE
Fix PDF document expansion problems

### DIFF
--- a/integration-impl/pom.xml
+++ b/integration-impl/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>se.idsec.signservice.integration</groupId>
     <artifactId>signservice-integration-parent</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.2-SNAPSHOT</version>
   </parent>
 
   <name>IDsec Solutions :: SignService :: Integration :: API Implementation</name>

--- a/pdf/pom.xml
+++ b/pdf/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>se.idsec.signservice.integration</groupId>
     <artifactId>signservice-integration-parent</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.2-SNAPSHOT</version>
   </parent>
 
   <name>IDsec Solutions :: SignService :: Integration :: PDF Processing</name>

--- a/pdf/src/main/java/se/idsec/signservice/integration/document/pdf/DefaultPdfSignaturePagePreparator.java
+++ b/pdf/src/main/java/se/idsec/signservice/integration/document/pdf/DefaultPdfSignaturePagePreparator.java
@@ -197,6 +197,8 @@ public class DefaultPdfSignaturePagePreparator implements PdfSignaturePagePrepar
     final List<PdfPrepareReport.PrepareActions> prepareActions = this.issueHandler.fixIssues(document,
         Optional.ofNullable(policyConfiguration.getPdfPrepareSettings()).orElse(PdfPrepareSettings.DEFAULT));
     if (!prepareActions.isEmpty()) {
+      // Document was altered (flattened / encryption removed) — compact the xref table.
+      document.getDocument().setHighestXRefObjectNumber(0);
       result.setPrepareReport(PdfPrepareReport.builder()
           .actions(prepareActions)
           .build());

--- a/pdf/src/main/java/se/idsec/signservice/integration/document/pdf/utils/PDDocumentUtils.java
+++ b/pdf/src/main/java/se/idsec/signservice/integration/document/pdf/utils/PDDocumentUtils.java
@@ -135,7 +135,8 @@ public class PDDocumentUtils {
           insertionPos++;
         }
       }
-
+      // Compact the xref table by renumbering from 0.
+      document.getDocument().setHighestXRefObjectNumber(0);
       return PDDocumentUtils.load(PDDocumentUtils.toBytes(document));
     }
     catch (final IndexOutOfBoundsException | IllegalStateException | IllegalArgumentException e) {

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>se.idsec.signservice.integration</groupId>
   <artifactId>signservice-integration-parent</artifactId>
   <packaging>pom</packaging>
-  <version>2.4.1-SNAPSHOT</version>
+  <version>2.4.2-SNAPSHOT</version>
 
   <name>IDsec Solutions :: Parent POM for SignService :: Integration</name>
   <description>Parent POM for SignService Integration libraries</description>

--- a/test-my-signature/pom.xml
+++ b/test-my-signature/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>se.idsec.signservice.integration</groupId>
     <artifactId>signservice-integration-parent</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.2-SNAPSHOT</version>
   </parent>
 
   <name>IDsec Solutions :: SignService :: Test my Signature</name>

--- a/xml/pom.xml
+++ b/xml/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>se.idsec.signservice.integration</groupId>
     <artifactId>signservice-integration-parent</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.2-SNAPSHOT</version>
   </parent>
 
   <name>IDsec Solutions :: SignService :: Integration :: XML Processing</name>


### PR DESCRIPTION
Bump version to 2.4.2-SNAPSHOT and compact xref table in PDF handling pre-sign logic on document updates.

fixes #85 